### PR TITLE
Maintain selected filter values after changing timespan

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,10 @@
 {
   "files.exclude": {
     "**/*.css": { "when": "$(basename).scss"}
-  }
+  },
+  "editor.rulers": [
+    120
+  ],
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2
 }

--- a/server/dashboards/preconfigured/bot-framework.js
+++ b/server/dashboards/preconfigured/bot-framework.js
@@ -406,12 +406,12 @@ return {
               channel: (val) => val || "unknown",
               channel_count: (val) => val || 0
             },
-            calculated: (filterChannels) => {
+            calculated: (filterChannels, dependencies, prevState) => {
               const filters = filterChannels.map((x) => x.channel);
-              let { selectedValues } = filterChannels;
-              if (selectedValues === undefined) {
-                selectedValues = [];
-              }
+              let selectedValues = [];
+              if (prevState['channels-selected'] !== undefined) {
+								selectedValues = prevState['channels-selected'];
+							}
               return {
                 "channels-count": filterChannels,
                 "channels-filters": filters,
@@ -429,12 +429,12 @@ return {
               intent: (val) => val || "unknown",
               intent_count: (val) => val || 0
             },
-            calculated: (filterIntents) => {
+            calculated: (filterIntents, dependencies, prevState) => {
               const intents = filterIntents.map((x) => x.intent);
-              let { selectedValues } = filterIntents;
-              if (selectedValues === undefined) {
-                selectedValues = [];
-              }
+              let selectedValues = [];
+              if (prevState['intents-selected'] !== undefined) {
+								selectedValues = prevState['intents-selected'];
+							}
               return {
                 "intents-count": filterIntents,
                 "intents-filters": intents,

--- a/server/dashboards/preconfigured/bot-framework.js
+++ b/server/dashboards/preconfigured/bot-framework.js
@@ -407,6 +407,11 @@ return {
               channel_count: (val) => val || 0
             },
             calculated: (filterChannels, dependencies, prevState) => {
+
+              // This code is meant to fix the following scenario:
+              // When "Timespan" filter changes, to "channels-selected" variable
+              // is going to be reset into an empty set.
+              // For this reason, using previous state to copy filter
               const filters = filterChannels.map((x) => x.channel);
               let selectedValues = [];
               if (prevState['channels-selected'] !== undefined) {

--- a/src/components/ElementConnector.tsx
+++ b/src/components/ElementConnector.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 import plugins from './generic/plugins';
 
 export default class ElementConnector {
-  static loadLayoutFromDashboard(elementsContainer: IElementsContainer, dashboard: IDashboardConfig) : ILayouts {
+  static loadLayoutFromDashboard(elementsContainer: IElementsContainer, dashboard: IDashboardConfig): ILayouts {
     
     var layouts = {};
     _.each(dashboard.config.layout.cols, (totalColumns, key) => {
@@ -23,11 +23,11 @@ export default class ElementConnector {
 
         layouts[key] = layouts[key] || [];
         layouts[key].push({
-          "i": id,
-          "x": curCol,
-          "y": curRowOffset,
-          "w": size.w,
-          "h": size.h
+          'i': id,
+          'x': curCol,
+          'y': curRowOffset,
+          'w': size.w,
+          'h': size.h
         });
 
         curCol += size.w;
@@ -44,7 +44,7 @@ export default class ElementConnector {
     dashboard.elements.forEach((element, idx) => {
       var ReactElement = plugins[element.type];
       var { id, dependencies, actions, props, title, subtitle, size, theme } = element;
-      var layoutProps = _.find(layout, { "i": id });
+      var layoutProps = _.find(layout, { 'i': id });
 
       elements.push(
         <div key={id}>
@@ -59,14 +59,14 @@ export default class ElementConnector {
                 theme={theme}
           />
         </div>
-      )
+      );
     });
 
     return elements;
   }
 
   static loadFiltersFromDashboard(dashboard: IDashboardConfig): {
-    filters : React.Component<any, any>[],
+    filters: React.Component<any, any>[],
     additionalFilters: React.Component<any, any>[]
   } {
     var filters = [];
@@ -82,7 +82,7 @@ export default class ElementConnector {
               subtitle={element.subtitle}
               icon={element.icon}
         />
-      )
+      );
     });
 
     return { filters, additionalFilters };

--- a/src/components/generic/GenericComponent.tsx
+++ b/src/components/generic/GenericComponent.tsx
@@ -89,7 +89,6 @@ export abstract class GenericComponent<T1 extends IGenericProps, T2 extends IGen
   }
 
   private onStateChange(state: any) {
-
     var result = DataSourceConnector.extrapolateDependencies(this.props.dependencies);
     var updatedState: IGenericState = {};
     Object.keys(result.dependencies).forEach(key => {

--- a/src/components/generic/MenuFilter.tsx
+++ b/src/components/generic/MenuFilter.tsx
@@ -126,9 +126,10 @@ export default class MenuFilter extends GenericComponent<any, any> {
   }
 
   render() {
-    var { title, subtitle, icon } = this.props;
-    var { selectedValues, values, overlay } = this.state;
+    const { title, subtitle, icon } = this.props;
+    let { selectedValues, values, overlay } = this.state;
     values = values || [];
+    selectedValues = selectedValues || [];
     let listItems = values.map((value, idx) => {
       return (
         <ListItemControl

--- a/src/components/generic/TextFilter.tsx
+++ b/src/components/generic/TextFilter.tsx
@@ -1,31 +1,22 @@
 import * as React from 'react';
 import { GenericComponent } from './GenericComponent';
-import Button from 'react-md/lib/Buttons/Button';
 import SelectField from 'react-md/lib/SelectFields';
 
-const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-
 export default class TextFilter extends GenericComponent<any, any> {
-  // static propTypes = {}
-  // static defaultProps = {}
 
-  constructor(props) {
+  constructor(props: any) {
     super(props);
 
     this.onChange = this.onChange.bind(this);
   }
 
-  onChange(newValue, index, event) {
+  onChange(newValue: any) {
     this.trigger('onChange', newValue);
   }
 
   render() {
     var { selectedValue, values } = this.state;
     values = values || [];
-
-    // var buttons = values.map((value, idx) => {
-    //   return <Button flat key={idx} label={value} primary={value === selectedValue} onClick={this.onChange.bind(null, value)} />
-    // })
 
     return (
         <SelectField
@@ -36,7 +27,7 @@ export default class TextFilter extends GenericComponent<any, any> {
           position={SelectField.Positions.BELOW}
           onChange={this.onChange}
           toolbar={false}
-          className='md-select-field--toolbar'
+          className="md-select-field--toolbar"
         />
     );
   }

--- a/src/data-sources/plugins/DataSourcePlugin.ts
+++ b/src/data-sources/plugins/DataSourcePlugin.ts
@@ -6,7 +6,7 @@ export interface IDataSourceOptions {
 }
 
 export interface ICalculated { 
-  [key: string]: (state: Object, dependencies: IDictionary) => any;
+  [key: string]: (state: Object, dependencies: IDictionary, prevState: Object) => any;
 }
 
 export interface IOptions<T> {
@@ -50,7 +50,7 @@ export abstract class DataSourcePlugin<T> implements IDataSourcePlugin {
     dependencies: {} as any,
     dependables: [],
     actions: [ 'updateDependencies', 'failure', 'updateSelectedValues' ],
-    params: <T>{},
+    params: <T> {},
     calculated: {}
   };
 
@@ -64,11 +64,12 @@ export abstract class DataSourcePlugin<T> implements IDataSourcePlugin {
     props.dependencies = options.dependencies || [];
     props.dependables = options.dependables || [];
     props.actions.push.apply(props.actions, options.actions || []);
-    props.params = <T>(options.params || {});
+    props.params = <T> (options.params || {});
     props.calculated = options.calculated || {};
 
     this.updateDependencies = this.updateDependencies.bind(this);
     this.updateSelectedValues = this.updateSelectedValues.bind(this);
+    this.getCalculated = this.getCalculated.bind(this);
   }
 
   abstract updateDependencies (dependencies: IDictionary, args: IDictionary, callback: (result: any) => void): void;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -38,7 +38,7 @@ interface IDataSource {
   type: string
   dependencies?: { [id: string]: string }
   params?: { [id: string]: any }
-  calculated?: (state, dependencies) => { [index: string]: any }
+  calculated?: (state, dependencies, prevState) => { [index: string]: any }
 }
 
 interface IElement {


### PR DESCRIPTION
The filter's selected values were not retained when changing the timespan and using forked queries. I believe this is because in forked queries only the result is passed back to the calculated method which will then clear the selected values property. 

One potential fix I found was to pass back the prevState to the calculated method so it can retain the selected values. @morsh you might know a better way to handle this?

NB: I applied a few linting updates while looking at these files, so the main change to look at is  `Query.ts` L138-142