### PR TITLE
Specify tslint dev-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "node-sass": "^4.5.0",
     "npm-run-all": "^4.0.2",
     "react-addons-test-utils": "^15.4.2",
-    "react-scripts-ts": "1.1.6"
+    "react-scripts-ts": "1.1.6",
+    "tslint": "^4.0.0"
   },
   "dependencies": {
     "alt": "^0.18.6",


### PR DESCRIPTION
We should specify the tslint version we need explicitly as tslint-loader only works with v4.