### PR TITLE
Show toast on data source error

### DIFF
--- a/src/data-sources/plugins/DataSourcePlugin.ts
+++ b/src/data-sources/plugins/DataSourcePlugin.ts
@@ -123,12 +123,11 @@ export abstract class DataSourcePlugin<T> implements IDataSourcePlugin {
   }
 
   private errorToMessage(error: any): string {
-    const exception = error as Error;
-    if (exception == null) {
+    if (!(error instanceof Error)) {
       return error;
     }
 
-    const message = exception.message;
+    const message = (error as Error).message;
     if (message === '[object ProgressEvent]') {
       return 'There is a problem connecting to the internet.';
     }

--- a/src/data-sources/plugins/DataSourcePlugin.ts
+++ b/src/data-sources/plugins/DataSourcePlugin.ts
@@ -1,4 +1,6 @@
 
+import { ToastActions } from '../../components/Toast';
+
 export interface IDataSourceOptions {
   dependencies: (string | Object)[];
   /** This would be variable storing the results */
@@ -116,6 +118,21 @@ export abstract class DataSourcePlugin<T> implements IDataSourcePlugin {
   }
 
   failure(error: any): void { 
+    ToastActions.addToast({ text: this.errorToMessage(error) });
     return error;
+  }
+
+  private errorToMessage(error: any): string {
+    const exception = error as Error;
+    if (exception == null) {
+      return error;
+    }
+
+    const message = exception.message;
+    if (message === '[object ProgressEvent]') {
+      return 'There is a problem connecting to the internet.';
+    }
+
+    return `Error: ${message}`;
   }
 }


### PR DESCRIPTION
Fixes #83 

Example error displayed when the connection to the data-source failed:

![image](https://cloud.githubusercontent.com/assets/1086421/26172698/2ded1bb6-3afe-11e7-9bc5-7e006e4e1a89.png)