### PR TITLE
Add integration with GraphQL

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -8,6 +8,7 @@ const fs = require('fs');
 const bodyParser = require('body-parser');
 const authRouter = require('./routes/auth');
 const apiRouter = require('./routes/api');
+const graphQLRouter = require('./routes/graphql');
 const cosmosDBRouter = require('./routes/cosmos-db');
 const azureRouter = require('./routes/azure');
 
@@ -30,8 +31,12 @@ app.use(morgan(':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:htt
 app.use(authRouter.authenticationMiddleware('/auth', '/api/setup'));
 app.use('/auth', authRouter.router);
 app.use('/api', apiRouter.router);
+<<<<<<< HEAD
 app.use('/cosmosdb', cosmosDBRouter.router);
 app.use('/azure', azureRouter.router);
+=======
+app.use('/graphql', graphQLRouter.router)
+>>>>>>> Add layer of indirection when querying GraphQL
 
 app.use(express.static(path.resolve(__dirname, '..', 'build')));
 

--- a/server/app.js
+++ b/server/app.js
@@ -31,12 +31,9 @@ app.use(morgan(':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:htt
 app.use(authRouter.authenticationMiddleware('/auth', '/api/setup'));
 app.use('/auth', authRouter.router);
 app.use('/api', apiRouter.router);
-<<<<<<< HEAD
 app.use('/cosmosdb', cosmosDBRouter.router);
 app.use('/azure', azureRouter.router);
-=======
 app.use('/graphql', graphQLRouter.router)
->>>>>>> Add layer of indirection when querying GraphQL
 
 app.use(express.static(path.resolve(__dirname, '..', 'build')));
 

--- a/server/routes/graphql.js
+++ b/server/routes/graphql.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const request = require('xhr-request');
+
+const router = new express.Router();
+
+router.post('/query', (req, res) => {
+  const { serviceUrl, query, variables } = req.body || { };
+
+  const requestOptions = {
+    method: 'POST',
+    json: true,
+    body: {
+      query: query,
+      variables: variables
+    },
+  };
+
+  request(serviceUrl, requestOptions, function(err, data) {
+    if (err) { throw err; }
+    return res.json(data);
+  });
+});
+
+module.exports = {
+  router
+}

--- a/src/data-sources/connections/graphql.tsx
+++ b/src/data-sources/connections/graphql.tsx
@@ -31,6 +31,17 @@ class GraphQLConnectionEditor extends ConnectionEditor<IConnectionProps, any> {
     return (
       <div>
         <h2 style={{ float: 'left', padding: 9 }}>GraphQL Connection</h2>
+        <InfoDrawer
+          width={300}
+          title="Authentication"
+          buttonIcon="help"
+          buttonTooltip="Click here to learn more about authentication"
+        >
+          <div>
+            Just enter the URL of the GraphQL service you wish to query below.
+            Currently only publicly accessible GraphQL endpoints are supported.
+          </div>
+        </InfoDrawer>
         <TextField
           id="serviceUrl"
           label={'Service URL'}

--- a/src/data-sources/connections/graphql.tsx
+++ b/src/data-sources/connections/graphql.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { IConnection, ConnectionEditor, IConnectionProps } from './Connection';
+import InfoDrawer from '../../components/common/InfoDrawer';
+import TextField from 'react-md/lib/TextFields';
+
+export default class GraphQLConnection implements IConnection {
+  type = 'graphql';
+  params = [ 'serviceUrl' ];
+  editor = GraphQLConnectionEditor;
+}
+
+class GraphQLConnectionEditor extends ConnectionEditor<IConnectionProps, any> {
+
+  constructor(props: IConnectionProps) {
+    super(props);
+
+    this.onParamChange = this.onParamChange.bind(this);
+  }
+
+  onParamChange(value: string, event: any) {
+    if (typeof this.props.onParamChange === 'function') {
+      this.props.onParamChange('graphql', event.target.id, value);
+    }
+  }
+
+  render() {
+
+    let { connection } = this.props;
+    connection = connection || {};
+
+    return (
+      <div>
+        <h2 style={{ float: 'left', padding: 9 }}>GraphQL Connection</h2>
+        <TextField
+          id="serviceUrl"
+          label={'Service URL'}
+          defaultValue={connection['serviceUrl'] || ''}
+          lineDirection="center"
+          placeholder="Fill in Service URL"
+          className="md-cell md-cell--bottom"
+          onChange={this.onParamChange}
+        />
+      </div>
+    );
+  }
+}

--- a/src/data-sources/connections/index.tsx
+++ b/src/data-sources/connections/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import ApplicationInsightsConnection from './application-insights';
+import GraphQLConnection from './graphql';
 import BotFrameworkConnection from './bot-framework';
 import CosmosDBConnection from './cosmos-db';
 import AzureConnection from './azure';
@@ -8,6 +9,7 @@ import { IConnection } from './Connection';
 
 var connectionTypes = [ 
   ApplicationInsightsConnection, 
+  GraphQLConnection,
   AzureConnection, 
   CosmosDBConnection, 
   BotFrameworkConnection ];

--- a/src/data-sources/plugins/GraphQL.ts
+++ b/src/data-sources/plugins/GraphQL.ts
@@ -47,8 +47,9 @@ export default class GraphQL extends DataSourcePlugin<IGraphQLParams> {
           query: query,
           variables: variables
         }
-      },      (error, json) => {
-        if (error) {
+      },      (err, json) => {
+        const error = err || (json['errors'] && json['errors'][0]);
+        if (error || json['errors']) {
           console.log(error);
           return this.failure(error);
         }

--- a/src/data-sources/plugins/GraphQL.ts
+++ b/src/data-sources/plugins/GraphQL.ts
@@ -1,0 +1,71 @@
+import * as request from 'xhr-request';
+
+import { DataSourcePlugin, IOptions } from './DataSourcePlugin';
+import GraphQLConnection from '../connections/graphql';
+import { DataSourceConnector } from '../DataSourceConnector';
+
+let connectionType = new GraphQLConnection();
+
+interface IGraphQLParams {
+  query: string;
+  variables: Object;
+}
+
+export default class GraphQL extends DataSourcePlugin<IGraphQLParams> {
+  type = 'GraphQL';
+  defaultProperty = 'data';
+  connectionType = connectionType.type;
+
+  constructor(options: IOptions<IGraphQLParams>, connections: IDict<IStringDictionary>) {
+    super(options, connections);
+    this.validateParams(this._props.params);
+  }
+
+  updateDependencies(dependencies: any) {
+    // Ensure dependencies exist
+    const isAnyDependencyMissing = Object.keys(this.getDependencies()).some(key => dependencies[key] == null);
+    if (isAnyDependencyMissing) {
+      return dispatch => dispatch();
+    }
+
+    // Validate connection
+    const connection = this.getConnection();
+    const { serviceUrl } = connection;
+    if (!connection || !serviceUrl) {
+      return dispatch => dispatch();
+    }
+
+    const params = this.getParams();
+    const { query, variables } = params;
+
+    return dispatch => {
+      request(serviceUrl, {
+        method: 'POST',
+        json: true,
+        body: {
+          query: query,
+          variables: variables
+        }
+      },      (error, json) => {
+        if (error) {
+          console.log(error);
+          return this.failure(error);
+        }
+
+        return dispatch(json);
+      });
+    };
+  }
+
+  updateSelectedValues(dependencies: IDictionary, selectedValues: any) {
+    if (Array.isArray(selectedValues)) {
+      return Object.assign(dependencies, { 'selectedValues': selectedValues });
+    } else {
+      return Object.assign(dependencies, { ... selectedValues });
+    }
+  }
+
+  private validateParams(params: IGraphQLParams): void {
+    return;
+  }
+}

--- a/src/data-sources/plugins/GraphQL.ts
+++ b/src/data-sources/plugins/GraphQL.ts
@@ -39,10 +39,11 @@ export default class GraphQL extends DataSourcePlugin<IGraphQLParams> {
     const { query, variables } = params;
 
     return dispatch => {
-      request(serviceUrl, {
+      request('/graphql/query', {
         method: 'POST',
         json: true,
         body: {
+          serviceUrl: serviceUrl,
           query: query,
           variables: variables
         }

--- a/src/data-sources/plugins/GraphQL.ts
+++ b/src/data-sources/plugins/GraphQL.ts
@@ -35,8 +35,8 @@ export default class GraphQL extends DataSourcePlugin<IGraphQLParams> {
       return dispatch => dispatch();
     }
 
-    const params = this.getParams();
-    const query = params.query;
+    const params = this.getParams() || ({} as IGraphQLParams);
+    const query = params.query || '';
     const variables = dependencies['variables'] || params.variables;
 
     return dispatch => {

--- a/src/data-sources/plugins/GraphQL.ts
+++ b/src/data-sources/plugins/GraphQL.ts
@@ -36,7 +36,8 @@ export default class GraphQL extends DataSourcePlugin<IGraphQLParams> {
     }
 
     const params = this.getParams();
-    const { query, variables } = params;
+    const query = params.query;
+    const variables = dependencies['variables'] || params.variables;
 
     return dispatch => {
       request('/graphql/query', {


### PR DESCRIPTION
This pull request adds a connection and data-source for GraphQL.

To test the integration, place the following content into a file called `graphql.private.js` in the `server/dashboards` folder:

```js
return {
  id: "graphql",
  name: "GraphQL",
  icon: "dashboard",
  url: "graphql",
  description: "A basic sample to see how a GraphQL service is connected to graphs",
  preview: "/images/bot-framework-preview.png",
  config: {
    connections: {
      graphql: { serviceUrl: "https://pokeapi-graphiql.herokuapp.com" }
    },
    layout: {
      isDraggable: true,
      isResizable: true,
      rowHeight: 30,
      verticalCompact: false,
      cols: { lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 },
      breakpoints: { lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }
    }
  },
  dataSources: [
    {
      id: "pokeIds",
      type: "Constant",
      params: { values: [12, 13, 14], selectedValue: 12 },
      calculated: (state, dependencies) => {
        return { variables: { pokeId: state.selectedValue } };
      }
    },
    {
      id: "graphql",
      type: "GraphQL",
      dependencies: { variables: "pokeIds:variables" },
      params: { 
        query: "query($pokeId:Int!){pokemon(number:$pokeId){name}}"
      },
      calculated: (state, dependencies) => {
        return { pokemons: [state.data.pokemon] };
      }
    }
  ],
  filters: [
    {
      type: "TextFilter",
      title: "PokeId",
      dependencies: { selectedValue: "pokeIds", values: "pokeIds:values" },
      actions: { onChange: "pokeIds:updateSelectedValue" },
      first: true
    },
  ],
  elements: [
    {
      id: "names",
      type: "Table",
      size: { w: 4, h: 8 },
      dependencies: {
        values: "graphql:pokemons"
      },
      props: {
        cols: [
          { header: "Name", field: "name" }
        ]
      },
    }
  ],
  dialogs: []
}
```

Open the thus-defined [dashboard](http://localhost:3000/dashboard/graphql) to fetch the name for a Pokemon from the [GraphQL PokeAPI](https://pokeapi-graphiql.herokuapp.com) and display it in an Ibex table:

![image](https://cloud.githubusercontent.com/assets/1086421/26267903/5a3ea654-3ca1-11e7-954a-c04005810220.png)

