### PR TITLE
Run tslint on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language:
+  node_js
+
+node_js:
+  - "7"
+
+install:
+  - yarn install
+
+env:
+  - NPM_COMMAND="lint"
+
+script:
+  - npm run $NPM_COMMAND

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "start:dev": "npm-run-all -p css:watch server:start client:start",
     "coverage": "react-scripts-ts test --env=jsdom --coverage --collectCoverageFrom=src/**/*.{ts,tsx} --collectCoverageFrom=!src/**/*.d.ts",
     "start": "node server",
+    "lint": "tslint src server",
     "build": "yarn run css:build && react-scripts-ts build",
     "test": "react-scripts-ts test --env=jsdom"
   }


### PR DESCRIPTION
This PR adds basic integration with Travis CI.

The CI will still have to be enabled by an admin of the ibex-dashboard repository on the [Travis site](https://travis-ci.org/CatalystCode/ibex-dashboard). I recommend the following setup which we use on [fortis-insights](https://travis-ci.org/CatalystCode/fortis-insights/settings):

![image](https://user-images.githubusercontent.com/1086421/26997608-6d0de3e0-4d7b-11e7-890a-9f6cdb62aa50.png)

For now, the only CI that is being run is the linter, but adding other tasks on the CI is easy, just a matter of adding another `NPM_COMMAND` to the env section. Using the env section instead of the scripts section has two advantages: (1) the tasks will get run in parallel instead of in sequence (2) it's easier to see what caused the build to fail, e.g. test issue or lint issue.