### PR TITLE
Automatically create production build via CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,7 @@ node_js:
   - "7"
 
 install:
-  - yarn install
-  - yarn run css:build
-
-env:
-  - YARN_COMMAND="lint"
-  - YARN_COMMAND="test"
+  - .travis/setup.sh
 
 script:
-  - CI=true yarn $YARN_COMMAND
+  - .travis/ci.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
 
 script:
   - .travis/ci.sh
+  - .travis/coverage.sh
 
 after_success:
   - .travis/push.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ install:
 
 script:
   - .travis/ci.sh
+
+after_success:
+  - .travis/push.sh

--- a/.travis/ci.sh
+++ b/.travis/ci.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+CI=true yarn lint
+CI=true yarn test

--- a/.travis/coverage.sh
+++ b/.travis/coverage.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+min_coverage="${MIN_COVERAGE:-42}"
+line_coverage="$(CI=true yarn coverage | grep '^All files  *|' | cut -d'|' -f5 | tr -d ' ' | cut -d'.' -f1)"
+
+if [ ${line_coverage} -lt ${min_coverage} ]; then
+  echo "Got test coverage of ${line_coverage} which is less than configured minimum of ${min_coverage}" >&2
+  exit 1
+else
+  echo "Got test coverage of ${line_coverage}, well done" >&2
+  exit 0
+fi

--- a/.travis/push.sh
+++ b/.travis/push.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly GITHUB_ORG="${GITHUB_ORG:-CatalystCode}"
+readonly GITHUB_REPO="${GITHUB_REPO:-ibex-dashboard}"
+readonly TARGET_BRANCH="${TARGET_BRANCH:-master}"
+
+log() {
+  echo "$@" >&2
+}
+
+ensure_preconditions_met() {
+  if [ "${TRAVIS_BRANCH}" != "${TARGET_BRANCH}" ]; then
+    log "Build is targetting ${TRAVIS_BRANCH}, not ${TARGET_BRANCH}"
+    log "Skipping creation of production build"
+    exit 0
+  fi
+  if [ -z "${GITHUB_TOKEN}" ]; then
+    log "GITHUB_TOKEN not set: won't be able to push production build"
+    log "Please configure the token in .travis.yml or the Travis UI"
+    exit 1
+  fi
+}
+
+create_production_build() {
+  CI="" yarn build
+}
+
+setup_git() {
+  git config user.name "Travis CI"
+  git config user.email "travis@travis-ci.org"
+  git remote add origin-travis "https://${GITHUB_TOKEN}@github.com/${GITHUB_ORG}/${GITHUB_REPO}.git"
+}
+
+commit_build_files() {
+  git checkout "${TARGET_BRANCH}"
+  git add --all build
+  echo -e "Travis build: ${TRAVIS_BUILD_NUMBER}\n\nhttps://travis-ci.org/${GITHUB_ORG}/${GITHUB_REPO}/builds/${TRAVIS_BUILD_ID}" | git commit --file -
+}
+
+push_to_github() {
+  git push origin-travis "${TARGET_BRANCH}:${TARGET_BRANCH}"
+}
+
+ensure_preconditions_met
+create_production_build
+setup_git
+commit_build_files
+push_to_github

--- a/.travis/push.sh
+++ b/.travis/push.sh
@@ -12,7 +12,7 @@ log() {
 
 ensure_preconditions_met() {
   if [ "${TRAVIS_BRANCH}" != "${TARGET_BRANCH}" ]; then
-    log "Build is targetting ${TRAVIS_BRANCH}, not ${TARGET_BRANCH}"
+    log "Build is targeting ${TRAVIS_BRANCH}, not ${TARGET_BRANCH}"
     log "Skipping creation of production build"
     exit 0
   fi

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+yarn install
+yarn run css:build


### PR DESCRIPTION
After merging this pull request, any Travis pull request targeting master will automatically build the JS/CSS on the CI server and commit the changes. This means that we don't have to manually run and commit the compiled artifacts anymore.

Here is a sample auto-build commit summary:

```diff
From 35a5d12763704d29acc94b449f3ff99ae16d3e08 Mon Sep 17 00:00:00 2001
From: Travis CI <travis@travis-ci.org>
Date: Tue, 13 Jun 2017 10:33:02 +0000
Subject: Travis build: 30

https://travis-ci.org/CatalystCode/ibex-dashboard/builds/242364464
---
 build/asset-manifest.json                                      | 4 ++--
 build/index.html                                               | 2 +-
 build/static/js/{main.d9fdb0ac.js => main.e51637f1.js}         | 2 +-
 build/static/js/{main.d9fdb0ac.js.map => main.e51637f1.js.map} | 2 +-
 4 files changed, 5 insertions(+), 5 deletions(-)
 rename build/static/js/{main.d9fdb0ac.js => main.e51637f1.js} (99%)
 rename build/static/js/{main.d9fdb0ac.js.map => main.e51637f1.js.map} (68%)
```

Here is a sample build that executed the auto-build [travis-ci/242364464](https://travis-ci.org/CatalystCode/ibex-dashboard/builds/242364464) and some of the auto-build logs for reference

![image](https://user-images.githubusercontent.com/1086421/27079350-97e05db4-5037-11e7-87f3-ab5a0a706414.png)

Note that in order to push the auto-build commit, the Travis machine authenticates with Github via an access token. Currently, this is a token associated with my personal Github account. After merging this pull request, **an administrator of ibex-dashboard should create a new access token** ([here](https://github.com/settings/tokens)) and then set this token as a secure environment variable in Travis ([here](https://travis-ci.org/CatalystCode/ibex-dashboard/settings)).