### PR TITLE
Trim whitespaces from connection values. Fixes #184

### DIFF
--- a/src/data-sources/connections/Connection.tsx
+++ b/src/data-sources/connections/Connection.tsx
@@ -21,7 +21,8 @@ abstract class ConnectionEditor<T1 extends IConnectionProps, T2> extends React.C
 
   onParamChange(value: string, event: any) {
     if (typeof this.props.onParamChange === 'function') {
-      this.props.onParamChange(event.target.id, value);
+      const trimmedValue = value.trim();
+      this.props.onParamChange(event.target.id, trimmedValue);
     }
   }
 }

--- a/src/data-sources/connections/Connection.tsx
+++ b/src/data-sources/connections/Connection.tsx
@@ -21,7 +21,7 @@ abstract class ConnectionEditor<T1 extends IConnectionProps, T2> extends React.C
 
   onParamChange(value: string, event: any) {
     if (typeof this.props.onParamChange === 'function') {
-      const trimmedValue = value.trim();
+      const trimmedValue = ('' + value).trim();
       this.props.onParamChange(event.target.id, trimmedValue);
     }
   }


### PR DESCRIPTION
Fixes minor issue when copying & pasting connection strings which may have leading / trailing whitespace. 